### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.reactnativesqlite2">
+          package="dog.craftz.sqlite_2">
 
 </manifest>


### PR DESCRIPTION
go back to the old package name since the new name caused a build error on Android